### PR TITLE
enhancement: set default sort field to createdAt

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -50,7 +50,7 @@ const HomePage = () => {
   const [isFetching, setIsFetching] = useState(false);
   const [redirects, setRedirects] = useState<RedirectType[]>([]);
   const [selectedRedirect, setSelectedRedirect] = useState<RedirectType | null>(null);
-  const [sortBy, setSortBy] = useState<string>('source');
+  const [sortBy, setSortBy] = useState<string>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
@@ -94,11 +94,15 @@ const HomePage = () => {
   };
 
   const handleSort = (field: string) => {
-    if (sortBy === field) {
-      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    if (sortBy === field && sortBy !== 'createdAt') {
+      if(sortOrder === 'desc') setSortOrder('asc');
+      else {
+        setSortOrder('desc');
+        setSortBy('createdAt');
+      }
     } else {
       setSortBy(field);
-      setSortOrder('asc');
+      setSortOrder('desc');
     }
     setNewPage(1);
   };


### PR DESCRIPTION
Sorting the redirects by createdAt by default is better UX. When you create a new redirect you can now quickly see it appear on top of the list. I also changed how this would work with clicking the table headers.
- default -> Sort **desc** by createdAt 
- 1st click -> Sort **desc** by field
- 2st click -> Sort **asc** by field
- 3rd click -> Sort **desc** by createdAt
- 4th click -> repeat 1st click