### PR TITLE
fix: body overflow

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -185,7 +185,7 @@ const HomePage = () => {
   }, [debouncedSearchTerm]);
 
   return (
-    <Main>
+    <Main style={{maxWidth: 'calc(100vw - 75px)'}}>
       <Layouts.Header
         primaryAction={
           <Flex gap={4}>
@@ -218,7 +218,7 @@ const HomePage = () => {
         )}
       />
       <Layouts.Content>
-        <Flex gap={4} direction="column" alignItems="stretch">
+        <Flex gap={4} direction="column" alignItems="stretch" marginBottom={8}>
           <Box paddingBottom={4}>
             <Flex gap={4} alignItems="center">
               <SearchForm>


### PR DESCRIPTION
### Problem
When a redirect has a long url, the page will horizontally overflow the body.

### Fix
Added a `maxWidth` to `<Main>` in order to prevent part of the page overflowing.

#### Notes:
- Maybe not the most elegant solution, but I can't seem to figure out how to get the page to stop overflowing any other way.
- I also added a bottom margin to the bottom of the page to prevent the pagination touching the page bottom.
