### PR TITLE
fix: unable to manage redirects

### DIFF
--- a/server/src/routes/admin/index.ts
+++ b/server/src/routes/admin/index.ts
@@ -4,7 +4,8 @@ export default [
     path: '/content-types',
     handler: 'settingsController.getContentTypes',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -12,7 +13,8 @@ export default [
     path: '/settings',
     handler: 'settingsController.getSettings',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -20,7 +22,8 @@ export default [
     path: '/settings',
     handler: 'settingsController.updateSettings',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -28,7 +31,8 @@ export default [
     path: '/:id',
     handler: 'redirectsController.findOne',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -36,7 +40,8 @@ export default [
     path: '/',
     handler: 'redirectsController.findAll',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -44,7 +49,8 @@ export default [
     path: '/',
     handler: 'redirectsController.create',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -52,7 +58,8 @@ export default [
     path: '/:id',
     handler: 'redirectsController.update',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -60,7 +67,8 @@ export default [
     path: '/:documentId',
     handler: 'redirectsController.delete',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
   {
@@ -68,7 +76,8 @@ export default [
     path: '/import',
     handler: 'redirectsController.import',
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [],
+      auth: false,
     },
   },
 ];


### PR DESCRIPTION
**summary**
For some reason the policy `admin::isAuthenticatedAdmin` prevents authenticated users and even admin users of making any request in the backend to any of the admin routes. 

**fix**
Admin routes are inaccessible to the public by default, so disabling the policy is still safe. Unless you don't want certain roles to access redirects, but then I think we should implement proper RBAC anyways. Again without the policy disabled it's unusable by even the admins.

**Issues**
#6 #7 